### PR TITLE
fix(heatmap): fixed tooltip not being shown for bottom values when x …

### DIFF
--- a/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/viewmodel/viewmodel.ts
@@ -251,7 +251,7 @@ export function shapeViewModel(
     if (x < chartDimensions.left || y < chartDimensions.top) {
       return [];
     }
-    if (x > chartDimensions.width + chartDimensions.left || y > chartDimensions.height) {
+    if (x > chartDimensions.width + chartDimensions.left || y > chartDimensions.height + chartDimensions.top) {
       return [];
     }
     const xValue = xInvertedScale(x - chartDimensions.left);


### PR DESCRIPTION
When the x axis labels were on top of the chart, it wouldn't show the tooltip when you mouse over values at the bottom of the chart. This has now been fixed with 22 additional characters.