### PR TITLE
Fix legend sizing

### DIFF
--- a/packages/charts/src/components/legend/_legend.scss
+++ b/packages/charts/src/components/legend/_legend.scss
@@ -5,7 +5,6 @@
   }
   &--horizontal {
     .echLegendList {
-      grid-column-gap: $echLegendColumnGap;
       grid-row-gap: $echLegendRowGap;
       margin-top: $echLegendRowGap;
       margin-bottom: $echLegendRowGap;

--- a/packages/charts/src/components/legend/legend.tsx
+++ b/packages/charts/src/components/legend/legend.tsx
@@ -86,7 +86,7 @@ function LegendComponent(props: LegendStateProps & LegendDispatchProps) {
 
   const positionConfig = getLegendPositionConfig(config.legendPosition);
   const containerStyle = getLegendStyle(positionConfig, size, legend.margin);
-  const listStyle = getLegendListStyle(positionConfig, chartMargins, legend, items.length);
+  const listStyle = getLegendListStyle(positionConfig, chartMargins, legend, items.length, size);
 
   const legendClasses = classNames('echLegend', {
     'echLegend--debug': debug,

--- a/packages/charts/src/components/legend/style_utils.ts
+++ b/packages/charts/src/components/legend/style_utils.ts
@@ -55,6 +55,7 @@ export function getLegendListStyle(
   chartMargins: Margins,
   legendStyle: ThemeLegendStyle,
   totalItems: number,
+  legendSize: BBox,
 ): LegendListStyle {
   const { top: paddingTop, bottom: paddingBottom, left: paddingLeft, right: paddingRight } = chartMargins;
 
@@ -62,7 +63,7 @@ export function getLegendListStyle(
     return {
       paddingLeft,
       paddingRight,
-      gridTemplateColumns: `repeat(auto-fill, minmax(${legendStyle.verticalWidth}px, 1fr))`,
+      gridTemplateColumns: `repeat(auto-fill, minmax(${Math.min(legendSize.width, legendStyle.verticalWidth)}px, 1fr))`,
     };
   }
 

--- a/packages/charts/src/state/selectors/get_legend_size.ts
+++ b/packages/charts/src/state/selectors/get_legend_size.ts
@@ -100,10 +100,11 @@ export const getLegendSizeSelector = createCustomCachedSelector(
     }
 
     // top or bottom legend
-    const isSingleLine = (parentDimensions.width - 20) / verticalWidth > labels.length;
+    const width = Math.floor(Math.min(legendItemWidth + spacingBuffer + actionDimension, verticalWidth));
+    const isSingleLine = (parentDimensions.width - 20) / width > labels.length;
     return {
       height: isSingleLine ? bbox.height + 16 : bbox.height * 2 + 24,
-      width: Math.floor(Math.min(legendItemWidth + spacingBuffer + actionDimension, verticalWidth)),
+      width,
       margin,
       position: legendPosition,
     };

--- a/packages/charts/src/state/selectors/get_legend_size.ts
+++ b/packages/charts/src/state/selectors/get_legend_size.ts
@@ -83,6 +83,7 @@ export const getLegendSizeSelector = createCustomCachedSelector(
     const actionDimension = isDefined(legendAction) ? 24 : 0; // max width plus margin
     const legendItemWidth = MARKER_WIDTH + SHARED_MARGIN + bbox.width + (showLegendDisplayValue ? SHARED_MARGIN : 0);
 
+    // left or right side legend
     if (legendPosition.direction === LayoutDirection.Vertical) {
       const legendItemHeight = bbox.height + VERTICAL_PADDING * 2;
       const legendHeight = legendItemHeight * labels.length + TOP_MARGIN;
@@ -97,7 +98,9 @@ export const getLegendSizeSelector = createCustomCachedSelector(
         position: legendPosition,
       };
     }
-    const isSingleLine = (parentDimensions.width - 20) / 200 > labels.length;
+
+    // top or bottom legend
+    const isSingleLine = (parentDimensions.width - 20) / verticalWidth > labels.length;
     return {
       height: isSingleLine ? bbox.height + 16 : bbox.height * 2 + 24,
       width: Math.floor(Math.min(legendItemWidth + spacingBuffer + actionDimension, verticalWidth)),

--- a/stories/line/6_curved.tsx
+++ b/stories/line/6_curved.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { boolean, select } from '@storybook/addon-knobs';
 import React from 'react';
 
 import {
@@ -34,70 +35,78 @@ import { KIBANA_METRICS } from '../../packages/charts/src/utils/data_samples/tes
 
 const dateFormatter = timeFormatter(niceTimeFormatByDay(1));
 
-export const Example = () => (
-  <Chart className="story-chart">
-    <Settings showLegend showLegendExtra legendPosition={Position.Right} />
-    <Axis id="bottom" position={Position.Bottom} showOverlappingTicks tickFormat={dateFormatter} />
-    <Axis
-      id="left"
-      title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
-      position={Position.Left}
-      tickFormat={(d) => `${Number(d).toFixed(0)}%`}
-    />
+export const Example = () => {
+  const doShowLegendExtra = boolean('show legend extra', true);
+  const legendPos = select(
+    'legend pos',
+    { top: Position.Top, left: Position.Left, right: Position.Right, bottom: Position.Bottom },
+    'right',
+  );
+  return (
+    <Chart className="story-chart">
+      <Settings showLegend showLegendExtra={doShowLegendExtra} legendPosition={legendPos} />
+      <Axis id="bottom" position={Position.Bottom} showOverlappingTicks tickFormat={dateFormatter} />
+      <Axis
+        id="left"
+        title={KIBANA_METRICS.metrics.kibana_os_load[0].metric.title}
+        position={Position.Left}
+        tickFormat={(d) => `${Number(d).toFixed(0)}%`}
+      />
 
-    <LineSeries
-      id="monotone x"
-      xScaleType={ScaleType.Time}
-      yScaleType={ScaleType.Linear}
-      xAccessor={0}
-      yAccessors={[1]}
-      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
-      curve={CurveType.CURVE_MONOTONE_X}
-    />
-    <LineSeries
-      id="basis"
-      xScaleType={ScaleType.Time}
-      yScaleType={ScaleType.Linear}
-      xAccessor={0}
-      yAccessors={[1]}
-      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
-      curve={CurveType.CURVE_BASIS}
-    />
-    <LineSeries
-      id="cardinal"
-      xScaleType={ScaleType.Time}
-      yScaleType={ScaleType.Linear}
-      xAccessor={0}
-      yAccessors={[1]}
-      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
-      curve={CurveType.CURVE_CARDINAL}
-    />
-    <LineSeries
-      id="catmull rom"
-      xScaleType={ScaleType.Time}
-      yScaleType={ScaleType.Linear}
-      xAccessor={0}
-      yAccessors={[1]}
-      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
-      curve={CurveType.CURVE_CATMULL_ROM}
-    />
-    <LineSeries
-      id="natural"
-      xScaleType={ScaleType.Time}
-      yScaleType={ScaleType.Linear}
-      xAccessor={0}
-      yAccessors={[1]}
-      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
-      curve={CurveType.CURVE_NATURAL}
-    />
-    <LineSeries
-      id="linear"
-      xScaleType={ScaleType.Time}
-      yScaleType={ScaleType.Linear}
-      xAccessor={0}
-      yAccessors={[1]}
-      data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
-      curve={CurveType.LINEAR}
-    />
-  </Chart>
-);
+      <LineSeries
+        id="monotone x"
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor={0}
+        yAccessors={[1]}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+        curve={CurveType.CURVE_MONOTONE_X}
+      />
+      <LineSeries
+        id="basis"
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor={0}
+        yAccessors={[1]}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+        curve={CurveType.CURVE_BASIS}
+      />
+      <LineSeries
+        id="cardinal"
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor={0}
+        yAccessors={[1]}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+        curve={CurveType.CURVE_CARDINAL}
+      />
+      <LineSeries
+        id="catmull rom"
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor={0}
+        yAccessors={[1]}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+        curve={CurveType.CURVE_CATMULL_ROM}
+      />
+      <LineSeries
+        id="natural"
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor={0}
+        yAccessors={[1]}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+        curve={CurveType.CURVE_NATURAL}
+      />
+      <LineSeries
+        id="linear"
+        xScaleType={ScaleType.Time}
+        yScaleType={ScaleType.Linear}
+        xAccessor={0}
+        yAccessors={[1]}
+        data={KIBANA_METRICS.metrics.kibana_os_load[0].data}
+        curve={CurveType.LINEAR}
+      />
+    </Chart>
+  );
+};

--- a/stories/stylings/4_theme_styling.tsx
+++ b/stories/stylings/4_theme_styling.tsx
@@ -148,10 +148,19 @@ export const Example = () => {
       ),
       defaultVizColor: DEFAULT_MISSING_COLOR,
     },
+    legend: {
+      verticalWidth: range('veticalWidth', 0, 300, 200),
+    },
   };
 
   const darkmode = boolean('darkmode', false, 'Colors');
   const className = darkmode ? 'story-chart-dark' : 'story-chart';
+  const legendPos = select(
+    'legend pos',
+    { top: Position.Top, left: Position.Left, right: Position.Right, bottom: Position.Bottom },
+    'right',
+  );
+  const doShowLegendExtra = boolean('show legend extra', true);
   switchTheme(darkmode ? 'dark' : 'light');
 
   return (
@@ -161,8 +170,8 @@ export const Example = () => {
         baseTheme={darkmode ? DARK_THEME : LIGHT_THEME}
         debug={boolean('debug', false)}
         showLegend
-        showLegendExtra
-        legendPosition={Position.Right}
+        showLegendExtra={doShowLegendExtra}
+        legendPosition={legendPos}
       />
       <Axis id="bottom" position={Position.Bottom} title="Bottom axis" showOverlappingTicks />
       <Axis id="left2" title="Left axis" position={Position.Left} tickFormat={(d) => Number(d).toFixed(2)} />


### PR DESCRIPTION
We want to let the legend grid with be less wide to match the content better. So we pass our calculation of legend width into the legend style creator. So it will now choose a column width that fits the content, unless the content is wider than the legendStyle.verticalWidth in which case it truncates.