### PR TITLE
Proper layout when the legend is on the side

### DIFF
--- a/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
@@ -108,8 +108,14 @@ export const computeChartDimensionsSelector = createCustomCachedSelector(
 
     if (config.xAxisLabel.position === 'top') {
       // move the top down to make space for the x axis labels
-      top = chartContainerDimensions.height - gridCellHeight * pageSize - legendSize.height;
+      top = chartContainerDimensions.height - gridCellHeight * pageSize;
     }
+    let legendHeight = 0;
+    if (showLegend && (legendPosition === Position.Top || legendPosition === Position.Bottom)) {
+      legendHeight = legendSize.height;
+      top -= legendSize.height;
+    }
+    height -= legendHeight;
 
     return {
       height,

--- a/stories/heatmap/2_categorical.tsx
+++ b/stories/heatmap/2_categorical.tsx
@@ -18,19 +18,29 @@
  */
 
 import { action } from '@storybook/addon-actions';
+import { select } from '@storybook/addon-knobs';
 import { extent } from 'd3-array';
 import React from 'react';
 
-import { Chart, Heatmap, ScaleType, Settings } from '../../packages/charts/src';
+import { Chart, Heatmap, Position, ScaleType, Settings } from '../../packages/charts/src';
 import { BABYNAME_DATA } from '../../packages/charts/src/utils/data_samples/babynames';
 
 export const Example = () => {
   const data = BABYNAME_DATA.filter(([year]) => year > 1950);
   const values = data.map((d) => +d[3]);
   const [min, max] = extent(values);
+
+  const legendPos = select('Legend position', ['top', 'right', 'bottom'], 'top');
+  const xAxisPosition = select('X Axis Position', ['top', 'bottom'], 'top');
+
   return (
     <Chart className="story-chart">
-      <Settings onElementClick={action('onElementClick')} showLegend legendPosition="right" brushAxis="both" />
+      <Settings
+        onElementClick={action('onElementClick')}
+        showLegend
+        legendPosition={legendPos as Position}
+        brushAxis="both"
+      />
       <Heatmap
         id="heatmap2"
         colorScale={ScaleType.Linear}
@@ -44,6 +54,10 @@ export const Example = () => {
         xSortPredicate="alphaAsc"
         config={{
           grid: {
+            // cellHeight: {
+            //   min: 0,
+            //   max: 20,
+            // },
             stroke: {
               width: 0,
             },
@@ -61,6 +75,9 @@ export const Example = () => {
           },
           yAxisLabel: {
             visible: true,
+          },
+          xAxisLabel: {
+            position: xAxisPosition,
           },
           onBrushEnd: action('onBrushEnd'),
         }}


### PR DESCRIPTION
## Summary
Fixes the issue in the category heatmap story where the legend on the right would cause the chart to render incorrectly.
