### PR TITLE
Heatmap excess label fix.

### DIFF
--- a/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
+++ b/packages/charts/src/chart_types/heatmap/renderer/canvas/canvas_renderers.ts
@@ -160,7 +160,19 @@ export function renderCanvas2d(
           } else if (labelRot === -90) {
             textAlign = 'right';
           }
-          heatmapViewModel.xValues.forEach((xValue) => {
+          const numVerticalGrids = heatmapViewModel.gridLines.x.length;
+          const numXLabels = heatmapViewModel.xValues.length;
+          let filteredXValues;
+          // if we are going to have more x labels than grid lines
+          // then we only render every nth x value, where n is numXLabels / numVerticalGrids
+          // this has the effect of only rendering one x axis label for each column in siutations
+          // where there would otherwise be too many
+          if (numXLabels > numVerticalGrids) {
+            const decreaseFactor = Math.ceil(numXLabels / numVerticalGrids);
+            filteredXValues = heatmapViewModel.xValues.filter((_, i) => i % decreaseFactor === 0);
+          }
+
+          (filteredXValues ?? heatmapViewModel.xValues).forEach((xValue) => {
             renderText(
               ctx,
               {

--- a/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/compute_chart_dimensions.ts
@@ -108,8 +108,14 @@ export const computeChartDimensionsSelector = createCustomCachedSelector(
 
     if (config.xAxisLabel.position === 'top') {
       // move the top down to make space for the x axis labels
-      top = chartContainerDimensions.height - gridCellHeight * pageSize - legendSize.height;
+      top = chartContainerDimensions.height - gridCellHeight * pageSize;
     }
+    let legendHeight = 0;
+    if (showLegend && (legendPosition === Position.Top || legendPosition === Position.Bottom)) {
+      legendHeight = legendSize.height;
+      top -= legendSize.height;
+    }
+    height -= legendHeight;
 
     return {
       height,

--- a/stories/heatmap/2_categorical.tsx
+++ b/stories/heatmap/2_categorical.tsx
@@ -18,19 +18,29 @@
  */
 
 import { action } from '@storybook/addon-actions';
+import { select } from '@storybook/addon-knobs';
 import { extent } from 'd3-array';
 import React from 'react';
 
-import { Chart, Heatmap, ScaleType, Settings } from '../../packages/charts/src';
+import { Chart, Heatmap, Position, ScaleType, Settings } from '../../packages/charts/src';
 import { BABYNAME_DATA } from '../../packages/charts/src/utils/data_samples/babynames';
 
 export const Example = () => {
   const data = BABYNAME_DATA.filter(([year]) => year > 1950);
   const values = data.map((d) => +d[3]);
   const [min, max] = extent(values);
+
+  const legendPos = select('Legend position', ['top', 'right', 'bottom'], 'top');
+  const xAxisPosition = select('X Axis Position', ['top', 'bottom'], 'top');
+
   return (
     <Chart className="story-chart">
-      <Settings onElementClick={action('onElementClick')} showLegend legendPosition="right" brushAxis="both" />
+      <Settings
+        onElementClick={action('onElementClick')}
+        showLegend
+        legendPosition={legendPos as Position}
+        brushAxis="both"
+      />
       <Heatmap
         id="heatmap2"
         colorScale={ScaleType.Linear}
@@ -44,6 +54,10 @@ export const Example = () => {
         xSortPredicate="alphaAsc"
         config={{
           grid: {
+            // cellHeight: {
+            //   min: 0,
+            //   max: 20,
+            // },
             stroke: {
               width: 0,
             },
@@ -61,6 +75,9 @@ export const Example = () => {
           },
           yAxisLabel: {
             visible: true,
+          },
+          xAxisLabel: {
+            position: xAxisPosition,
           },
           onBrushEnd: action('onBrushEnd'),
         }}


### PR DESCRIPTION
## Summary
Before, when the heatmap has enough space to render multiple x axis labels per column, there would be more labels than data. Now we prevent this behavior. 

This also fixes an issue with the legend causing bad layout when it was on the side.
